### PR TITLE
Fix redundancy with `::new()` showed in #5

### DIFF
--- a/src/commands/threads.rs
+++ b/src/commands/threads.rs
@@ -62,11 +62,11 @@ async fn set_media_channel(ctx: &Context, msg: &Message, args: Args) -> CommandR
     match matches {
         Ok(matches) => {
             // TODO: Actually do stuff here
-            let mut channel_options = ChannelOptions::new();
-
-            channel_options.admin_talk = matches.is_present("admin_talk");
-            channel_options.mod_talk = matches.is_present("mod_talk");
-            channel_options.member_talk = matches.is_present("member_talk");
+            let channel_options = ChannelOptions {
+                admin_talk: matches.is_present("admin_talk"),
+                mod_talk: matches.is_present("mod_talk"),
+                member_talk: matches.is_present("member_talk"),
+            };
 
             let mut data = ctx.data.write().await;
             let db = data

--- a/src/data_structs.rs
+++ b/src/data_structs.rs
@@ -10,22 +10,11 @@ pub struct MediaChannel;
 // TODO
 // pub struct ThreadOptions {}
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Default)]
 pub struct ChannelOptions {
     pub mod_talk: bool,
     pub admin_talk: bool,
     pub member_talk: bool,
-}
-
-#[allow(dead_code)]
-impl ChannelOptions {
-    pub fn new() -> Self {
-        Self {
-            mod_talk: false,
-            admin_talk: false,
-            member_talk: false,
-        }
-    }
 }
 
 impl TypeMapKey for Prefixes {


### PR DESCRIPTION
#5
Testing is needed