### PR TITLE
Remove unnecessary `#[derive(default)]` from `ChannelOptions`

### DIFF
--- a/src/data_structs.rs
+++ b/src/data_structs.rs
@@ -10,7 +10,7 @@ pub struct MediaChannel;
 // TODO
 // pub struct ThreadOptions {}
 
-#[derive(Clone, Serialize, Deserialize, Default)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ChannelOptions {
     pub mod_talk: bool,
     pub admin_talk: bool,


### PR DESCRIPTION
Yet another commit based on #5 